### PR TITLE
Placing a continue statement in the inflate/deflate loop while encountering buffer error as per zlib documentation

### DIFF
--- a/DCTar.m
+++ b/DCTar.m
@@ -632,8 +632,6 @@ static int format_octal(int64_t v, char *p, int s)
         strm.avail_out = (uInt)([compressed length] - strm.total_out);
         
         deflate(&strm, Z_FINISH);
-        if(status == Z_BUF_ERROR)
-            continue;
         
     } while (strm.avail_out == 0);
     


### PR DESCRIPTION
For large files **buffer error** is thrown due to either avail_in or avail_out becoming zero while inflate/deflate. 
**_Continuing**_ the loop when buffer error is encountered as per the zlib documentation resolves this issue.
