### PR TITLE
fix size 0 bug

### DIFF
--- a/DCTar.m
+++ b/DCTar.m
@@ -313,9 +313,10 @@ static const char template_header[] = {
                 
                 if(size == 0) {
                     [@"" writeToFile:filePath atomically:YES encoding:NSUTF8StringEncoding error:error];
+                } else {
+                    blockCount += (size - 1) / TAR_BLOCK_SIZE + 1; // size/TAR_BLOCK_SIZE rounded up
                 }
                 
-                blockCount += (size - 1) / TAR_BLOCK_SIZE + 1; // size/TAR_BLOCK_SIZE rounded up
                 [self writeFileDataForObject:tarObject atLocation:(location + TAR_BLOCK_SIZE) withLength:size atPath:filePath];
                 
             } else if(type == '5') {


### PR DESCRIPTION
When block size is 0, calculation of `blockCount` cause underflow.
This PR fix it.

Please solve issue #14 before merge this PR.

A commit `2bc2873150f624d6275132ae2ba37af561ea0c52` have some bugs.
So If you merge it to `master`, no one can use it.
I am using earlier one for it (`v0.1.3`).

If you remove these unnecessary `free`,
it has more bugs and I got crash.