### PR TITLE
Fix invalid error

### DIFF
--- a/DCTar.m
+++ b/DCTar.m
@@ -313,9 +313,10 @@ static const char template_header[] = {
                 
                 if(size == 0) {
                     [@"" writeToFile:filePath atomically:YES encoding:NSUTF8StringEncoding error:error];
+                } else {
+                    blockCount += (size - 1) / TAR_BLOCK_SIZE + 1; // size/TAR_BLOCK_SIZE rounded up
                 }
                 
-                blockCount += (size - 1) / TAR_BLOCK_SIZE + 1; // size/TAR_BLOCK_SIZE rounded up
                 [self writeFileDataForObject:tarObject atLocation:(location + TAR_BLOCK_SIZE) withLength:size atPath:filePath];
                 
             } else if(type == '5') {

--- a/DCTar.m
+++ b/DCTar.m
@@ -312,7 +312,7 @@ static const char template_header[] = {
                 //NSLog(@"file created: %@",name);
                 
                 if(size == 0) {
-                    [@"" writeToFile:filePath atomically:YES encoding:NSUTF8StringEncoding error:error];
+                    [@"" writeToFile:filePath atomically:YES encoding:NSUTF8StringEncoding error:nil];
                 } else {
                     blockCount += (size - 1) / TAR_BLOCK_SIZE + 1; // size/TAR_BLOCK_SIZE rounded up
                 }


### PR DESCRIPTION
This line of code occurs that returns `YES` with `NSError` on `error`.
It violates cocoa error handling convention.
When we call this method from Swift with Objective-C interop, 
this invalid state occurs undeterministic runtime crash.

This PR fix this issue by passing nil to `error:` for invocation of `writeToFile` without handling error.  

This PR includes #16 