### PR TITLE
Fix documentation markup in DCTar.h

### DIFF
--- a/DCTar.h
+++ b/DCTar.h
@@ -18,109 +18,109 @@
 
 /**
  Create a gzipped tar file from a file or directory.
- @param: filePath is the path to file on disk.
- @param: toPath is the path to create the tar at.
- @param: error is used to report back if an error happened.
+ @param filePath is the path to file on disk.
+ @param toPath is the path to create the tar at.
+ @param error is used to report back if an error happened.
  @return if the compression was successful or not.
  */
 +(BOOL)compressFileAtPath:(NSString*)filePath toPath:(NSString*)toPath error:(NSError**)error;
 
 /**
  Create a gzipped tar file from a data blob.
- @param: data is the file data blob to create a tar with.
- @param: toPath is the path to create the tar at.
- @param: error is used to report back if an error happened.
+ @param data is the file data blob to create a tar with.
+ @param toPath is the path to create the tar at.
+ @param error is used to report back if an error happened.
  @return if the compression was successful or not.
  */
 //+(BOOL)compressData:(NSData*)data toPath:(NSString*)path error:(NSError**)error;
 
 /**
  decompress a tar or gzipped tar (.tar or tar.giz) file.
- @param: filePath is the path to the tar file on disk.
- @param: toPath is the directory path to create the export data at.
- @param: error is used to report back if an error happened.
+ @param filePath is the path to the tar file on disk.
+ @param path is the directory path to create the export data at.
+ @param error is used to report back if an error happened.
  @return if the decompression was successful or not.
  */
 +(BOOL)decompressFileAtPath:(NSString*)filePath toPath:(NSString*)path error:(NSError**)error;
 
 /**
  decompress a tar or gzipped tar (.tar or tar.giz) file.
- @param: data is the file tar blob to decompress.
- @param: toPath is the directory path to create the export data at.
- @param: error is used to report back if an error happened.
+ @param data is the file tar blob to decompress.
+ @param path is the directory path to create the export data at.
+ @param error is used to report back if an error happened.
  @return if the decompression was successful or not.
  */
 +(BOOL)decompressData:(NSData*)data toPath:(NSString*)path error:(NSError**)error;
 
 /**
  Create a tar file (no gzipping) from a file or directory.
- @param: filePath is the path to file on disk.
- @param: toPath is the path to create the tar at.
- @param: error is used to report back if an error happened.
+ @param tarFilePath is the path to file on disk.
+ @param path is the path to create the tar at.
+ @param error is used to report back if an error happened.
  @return if the compression was successful or not.
  */
 +(BOOL)tarFileAtPath:(NSString*)tarFilePath toPath:(NSString*)path error:(NSError**)error;
 
 /**
  decompress a tar file.
- @param: filePath is the path to the tar file on disk.
- @param: toPath is the directory path to create the export data at.
- @param: error is used to report back if an error happened.
+ @param tarFilePath is the path to the tar file on disk.
+ @param path is the directory path to create the export data at.
+ @param error is used to report back if an error happened.
  @return if the decompression was successful or not.
  */
 +(BOOL)untarFileAtPath:(NSString*)tarFilePath toPath:(NSString*)path error:(NSError**)error;
 
 /**
  Create a tar file (not gzipped) from a data blob.
- @param: data is the file data blob to create a tar with.
- @param: toPath is the path to create the tar at.
- @param: error is used to report back if an error happened.
+ @param data is the file data blob to create a tar with.
+ @param toPath is the path to create the tar at.
+ @param error is used to report back if an error happened.
  @return if the compression was successful or not.
  */
 //+(BOOL)tarData:(NSData*)tarData toPath:(NSString*)path error:(NSError**)error;
 
 /**
  decompress a tar file (not gzipped).
- @param: data is the file tar blob to decompress.
- @param: toPath is the directory path to create the export data at.
- @param: error is used to report back if an error happened.
+ @param tarData is the file tar blob to decompress.
+ @param path is the directory path to create the export data at.
+ @param error is used to report back if an error happened.
  @return if the decompression was successful or not.
  */
 +(BOOL)untarData:(NSData*)tarData toPath:(NSString*)path error:(NSError**)error;
 
 /**
  gzipped some data.
- @param: The data to gzip.
+ @param data The data to gzip.
  @return The newly gzipped data.
  */
 +(NSData*)gzipCompress:(NSData*)data;
 
 /**
  decompress a gzipped data blob.
- @param: The data to ungzip.
+ @param data The data to ungzip.
  @return The newly unzipped data.
  */
 +(NSData*)gzipDecompress:(NSData*)data;
 
 /**
  decompress a gzipped file.
- @param: filePath is the path to file on disk.
- @param: toPath is the path to create the tar at.
- @param: error is used to report back if an error happened.
+ @param filePath is the path to file on disk.
+ @param toPath is the path to create the tar at.
+ @param error is used to report back if an error happened.
  @return if the compression was successful or not.
  */
 +(BOOL)gzipDecompress:(NSString*)filePath toPath:(NSString*)toPath error:(NSError**)error;
 
 /**
  decompress a zlib data blob.
- @param: The data to decompress.
+ @param data The data to decompress.
  @return The newly decompressed data.
  */
 +(NSData*)zlibDecompress:(NSData*)data;
 
 /**
  compress a zlib data blob.
- @param: The data to compress.
+ @param data The data to compress.
  @return The newly compressed data.
  */
 +(NSData*)zlibCompress:(NSData*)data;


### PR DESCRIPTION
There were 2 little problems with markup which caused warnings in Xcode 11.3.
1) Colon ':' after `@param` caused "Parameter ':' not found in the function declaration" warnings.
2) Parameter name mismatch caused warnings like "Parameter 'toPath' not found in the function declaration". 
This fix insures that docs work as expected.